### PR TITLE
Enhancement: Add Ruby warning category opt-in to test helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'net-http', '~> 0.2'  # For HTTP requests
 
 group :test do
   gem 'rspec', '~> 3.13'
+  gem 'warning'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     sqlite3 (2.9.4-x86_64-darwin)
     sqlite3 (2.9.4-x86_64-linux-gnu)
     uri (1.1.1)
+    warning (1.6.0)
     yard (0.9.43)
     yard-lint (1.5.1)
       yard (~> 0.9)
@@ -52,6 +53,7 @@ DEPENDENCIES
   rspec (~> 3.13)
   rubyzip (~> 3.0)
   sqlite3 (~> 2.0)
+  warning
   yard-lint
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
-else
-  Warning[:deprecated] = true
-  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
 
 Warning.process do |warning|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= '3.3'
-Warning[:deprecated] = true
+require 'warning'
+
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
+else
+  Warning[:deprecated] = true
+  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
-
-require 'warning'
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each do |cat|
+    Warning[cat] = true
+  end
 end
 
 require 'warning'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,6 @@ end
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
   next if warning.include?('_spec')
-  next if warning.include?('previous definition of')
-  next if warning.include?('method redefined')
   next if warning.include?('vendor/')
   next if warning.include?('bundle/')
   next if warning.include?('.bundle/')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
 end
 
 require 'warning'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+Warning[:performance] = true if RUBY_VERSION >= '3.3'
+Warning[:deprecated] = true
+$VERBOSE = true
+
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
+require 'warning'
+
+Warning.process do |warning|
+  next unless warning.include?(Dir.pwd)
+  next if warning.include?('_spec')
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+  next if warning.include?('vendor/')
+  next if warning.include?('bundle/')
+  next if warning.include?('.bundle/')
+  raise "Warning in your code: #{warning}"
+end
+
 require 'fileutils'
 
 # Set up test environment


### PR DESCRIPTION
## Summary

- Adds the `warning` gem to the `:test` group in `Gemfile`
- Adds Ruby warning category opt-in configuration at the top of `spec/spec_helper.rb`, enabling `Warning[:deprecated]`, `Warning[:performance]` (Ruby >= 3.3), and all other available warning categories
- Sets up a `Warning.process` block that raises on any warnings originating from project code (excluding specs, vendor, and bundle paths), turning warnings into test failures for early detection

## Test plan

- [ ] Run `bundle install` to confirm the `warning` gem installs cleanly
- [ ] Run `bundle exec rspec` and verify tests pass without unexpected warning failures
- [ ] Confirm that any genuine code warnings in lib files are surfaced as test errors